### PR TITLE
[apps] Syncthing config on default provisioner

### DIFF
--- a/apps/gammasite-prod/syncthing-patch-values.yaml
+++ b/apps/gammasite-prod/syncthing-patch-values.yaml
@@ -8,12 +8,6 @@ metadata:
 spec:
   values:
     persistence:
-      config:
-        enabled: true
-        type: pvc
-        existingClaim: datapool-shared-config
-        subPath: syncthing-config
-        mountPath: /var/syncthing
       videos:
         enabled: true
         readOnly: false


### PR DESCRIPTION
Performance is fairly poor on the same array its scanning, moving to default provisioner for speed

Removing the patched config will move to default, which will be on the boot SSD. Manual data migration needed after merge.