### PR TITLE
Add a service for Philips Hue emulation on HA

### DIFF
--- a/apps/gammasite-prod/patch-values.yaml
+++ b/apps/gammasite-prod/patch-values.yaml
@@ -217,6 +217,18 @@ spec:
     persistence:
       config:
         existingClaim: homeassistant-config
+    service:
+      hue:
+        enabled: true
+        type: LoadBalancer
+        externalTrafficPolicy: Local
+        annotations:
+          metallb.universe.tf/loadBalancerIPs: ${metallb_ip_hue}
+        ports:
+          hue:
+            enabled: true
+            port: 80
+            protocol: TCP
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/clusters/gammasite-prod/apps.yaml
+++ b/clusters/gammasite-prod/apps.yaml
@@ -31,7 +31,7 @@ spec:
       host_path_base: /rocketpool/kube/pvs
       metallb_ip_deluge: 192.168.0.61
       metallb_ip_plex: 192.168.0.62
-      metallb_ip_factorio: 192.168.0.63
+      metallb_ip_hue: 192.168.0.63
       metallb_ip_syncthing: 192.168.0.64
       metallb_ip_unifi: 192.168.0.65
       metallb_ip_mqtt: 192.168.0.66

--- a/clusters/gammasite-prod/infrastructure.yaml
+++ b/clusters/gammasite-prod/infrastructure.yaml
@@ -32,7 +32,7 @@ spec:
       # These are only used in the apps kustomization but listed here to avoid duplication
       metallb_ip_deluge: 192.168.0.61
       metallb_ip_plex: 192.168.0.62
-      metallb_ip_factorio: 192.168.0.63
+      metallb_ip_hue: 192.168.0.63
       metallb_ip_syncthing: 192.168.0.64
       metallb_ip_unifi: 192.168.0.65
       metallb_ip_mqtt: 192.168.0.66


### PR DESCRIPTION
Port 80 forwarded to the container on a TCP listener