### PR TITLE
Disable jellyfin on tesla cluster

### DIFF
--- a/apps/teslops/kustomization.yaml
+++ b/apps/teslops/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../sources
   - ../base/hajimari.yaml
   - ./plex
-  - ./jellyfin
   - ./syncthing
   - ./tautulli
   - ./frigate


### PR DESCRIPTION
Update #681 has broken jellyfin so disabling for now to quieten it