### PR TITLE
Remove High Quality Tapo streams

### DIFF
--- a/apps/deltasite/frigate/patch.yaml
+++ b/apps/deltasite/frigate/patch.yaml
@@ -105,12 +105,10 @@ spec:
               - 0,0,0,360,300,360,300,0
           ffmpeg:
             inputs:
-              - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.66/stream1
-                roles:
-                  - record
               - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.66/stream2
                 roles:
                   - detect
+                  - record
         Chicken-Watch:
           motion:
             mask:
@@ -125,12 +123,10 @@ spec:
                   - 640,120,640,360,0,360,0,218,232,120
           ffmpeg:
             inputs:
-              - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.187/stream1
-                roles:
-                  - record
               - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.187/stream2
                 roles:
                   - detect
+                  - record
     persistence:
       media:
         existingClaim: frigate-data-pvc


### PR DESCRIPTION
Events triggering on these streams are pushing the very limited bandwidth so removing for now until we can improve the wifi link