### PR TITLE
Switch frigate to app-template

### DIFF
--- a/apps/base/frigate.yaml
+++ b/apps/base/frigate.yaml
@@ -8,11 +8,11 @@ spec:
   interval: 15m
   chart:
     spec:
-      chart: frigate
-      version: 7.5.1
+      chart: app-template
+      version: 3.4.0
       sourceRef:
         kind: HelmRepository
-        name: blakeblackshear
+        name: bjw-s
         namespace: flux-system
   maxHistory: 3
   install:
@@ -26,20 +26,38 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    image:
-      repository: ghcr.io/blakeblackshear/frigate
-      tag: 0.14.1
-    config: |
-      mqtt:
-        enabled: False
-      cameras:
-        dummy_camera: # <--- this will be changed to your actual camera later
-          enabled: False
-          ffmpeg:
-            inputs:
-              - path: rtsp://127.0.0.1:554/rtsp
-                roles:
-                  - detect
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              repository: ghcr.io/blakeblackshear/frigate
+              tag: 0.14.1
+            env:
+              TZ: "Europe/Dublin"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: &port 5000
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+            securityContext:
+              privileged: true
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *port
     ingress:
       enabled: true
       ingressClassName: nginx
@@ -52,8 +70,22 @@ spec:
             - '/'
     persistence:
       config:
-        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
         size: 1Gi
       media:
-        enabled: true
-        size: 25Gi
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 50Gi
+      cache:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 4Gi
+        globalMounts:
+          - path: /dev/shm
+      usb:
+        type: hostPath
+        hostPath: /dev/bus/usb
+        hostPathType: Directory
+        globalMounts:
+          - path: /dev/bus/usb

--- a/apps/deltasite/frigate/configmap.yaml
+++ b/apps/deltasite/frigate/configmap.yaml
@@ -1,0 +1,131 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frigate-configmap
+  namespace: default
+data:
+  config.yml: |
+    mqtt:
+      enabled: False
+    record:
+      enabled: True
+      sync_recordings: True
+      retain:
+        days: 2
+        mode: all
+      events:
+        retain:
+          default: 90
+          mode: active_objects
+    detectors:
+      coral:
+        type: edgetpu
+        device: usb
+    ffmpeg:
+      hwaccel_args: preset-rpi-64-h264
+    objects:
+      track:
+        - person
+        - cat
+        - dog
+        - cow
+        - car
+        - motorcycle
+        - bird
+    cameras:
+      Shed_Door:
+        enabled: True
+        detect:
+          enabled: False
+        ffmpeg:
+          inputs:
+            - path: rtsp://192.168.3.20:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
+              roles:
+                - detect
+                - record
+      Front_Gate:
+        enabled: True
+        motion:
+          mask:
+            - 420,50,0,70,0,0,380,0,420,0
+        ffmpeg:
+          inputs:
+            - path: rtsp://admin:adminadmin@192.168.3.21:554//h265Preview_01_main
+              roles:
+                - record
+            - path: rtsp://admin:adminadmin@192.168.3.21:554//h264Preview_01_sub
+              roles:
+                - detect
+      Back_Corner:
+        enabled: True
+        detect:
+          enabled: False
+        ffmpeg:
+          inputs:
+            - path: rtsp://192.168.3.22:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
+              roles:
+                - record
+                - detect
+      Back_Door:
+        enabled: True
+        motion:
+          mask:
+            - 1280,0,1280,483,444,0
+        objects:
+          track:
+            - person
+            - dog
+            - car
+          filters:
+            person:
+              mask:
+                - 200,300,300,300,300,500,200,500
+        ffmpeg:
+          inputs:
+            - path: rtsp://192.168.3.23:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
+              roles:
+                - detect
+                - record
+      Lower_Yard:
+        enabled: True
+        detect:
+          enabled: False
+        ffmpeg:
+          inputs:
+            - path: rtsp://192.168.3.24:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
+              roles:
+                - record
+                - detect
+      Oak_Lodge_Driveway:
+        motion:
+          mask:
+            - 0,0,0,1,0.292,1,0.164,0.292,1,0.509,1,0
+        objects:
+          filters:
+            cow:
+              mask:
+                - 0.317,0.362,1,0.692,1,0,0.317,0
+        ffmpeg:
+          inputs:
+            - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.66/stream2
+              roles:
+                - detect
+            - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.66/stream1
+              roles:
+                - record
+      Chicken_Watch:
+        motion:
+          mask:
+            - 640,0,640,90,0,90,0,0
+        objects:
+          track:
+            - person
+            - cat
+            - dog
+            - cow
+        ffmpeg:
+          inputs:
+            - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.187/stream2
+              roles:
+                - detect
+                - record

--- a/apps/deltasite/frigate/kustomization.yaml
+++ b/apps/deltasite/frigate/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - frigate.yaml
   - pvc.yaml
-  - ../../base/frigate.yaml
 patchesStrategicMerge:
   - patch.yaml

--- a/apps/deltasite/frigate/patch.yaml
+++ b/apps/deltasite/frigate/patch.yaml
@@ -6,133 +6,21 @@ metadata:
   namespace: default
 spec:
   values:
-    coral:
-      enabled: true
-    config: |
-      mqtt:
-        enabled: False
-      record:
-        enabled: True
-        sync_recordings: True
-        retain:
-          days: 2
-          mode: all
-        events:
-          retain:
-            default: 90
-            mode: active_objects
-      detectors:
-        coral:
-          type: edgetpu
-          device: usb
-      ffmpeg:
-        hwaccel_args: preset-rpi-64-h264
-      objects:
-        track:
-          - person
-          - cat
-          - dog
-          - cow
-          - car
-          - motorcycle
-          - bird
-      cameras:
-        Shed_Door:
-          enabled: True
-          detect:
-            enabled: False
-          ffmpeg:
-            inputs:
-              - path: rtsp://192.168.3.20:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - detect
-                  - record
-        Front_Gate:
-          enabled: True
-          motion:
-            mask:
-              - 420,50,0,70,0,0,380,0,420,0
-          ffmpeg:
-            inputs:
-              - path: rtsp://admin:adminadmin@192.168.3.21:554//h265Preview_01_main
-                roles:
-                  - record
-              - path: rtsp://admin:adminadmin@192.168.3.21:554//h264Preview_01_sub
-                roles:
-                  - detect
-        Back_Corner:
-          enabled: True
-          detect:
-            enabled: False
-          ffmpeg:
-            inputs:
-              - path: rtsp://192.168.3.22:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - record
-                  - detect
-        Back_Door:
-          enabled: True
-          motion:
-            mask:
-              - 1280,0,1280,483,444,0
-          objects:
-            track:
-              - person
-              - dog
-              - car
-            filters:
-              person:
-                mask:
-                  - 200,300,300,300,300,500,200,500
-          ffmpeg:
-            inputs:
-              - path: rtsp://192.168.3.23:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - detect
-                  - record
-        Lower_Yard:
-          enabled: True
-          detect:
-            enabled: False
-          ffmpeg:
-            inputs:
-              - path: rtsp://192.168.3.24:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - record
-                  - detect
-        Oak_Lodge_Driveway:
-          motion:
-            mask:
-              - 0,0,0,1,0.292,1,0.164,0.292,1,0.509,1,0
-          objects:
-            filters:
-              cow:
-                mask:
-                  - 0.317,0.362,1,0.692,1,0,0.317,0
-          ffmpeg:
-            inputs:
-              - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.66/stream2
-                roles:
-                  - detect
-              - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.66/stream1
-                roles:
-                  - record
-        Chicken_Watch:
-          motion:
-            mask:
-              - 640,0,640,90,0,90,0,0
-          objects:
-            track:
-              - person
-              - cat
-              - dog
-              - cow
-          ffmpeg:
-            inputs:
-              - path: rtsp://camera:eZW2tHGfVf_zLjxTgsBm@192.168.3.187/stream2
-                roles:
-                  - detect
-                  - record
     persistence:
+      config:
+        existingClaim: frigate-config
+        type: null
+        accessMode: null
+        size: null
+      config-file:
+        type: configMap
+        name: frigate-configmap
+        globalMounts:
+          - path: /config/config.yml
+            subPath: config.yml
+            readOnly: true
       media:
-        existingClaim: frigate-data-pvc
+        existingClaim: frigate-media-pvc
+        type: null
+        accessMode: null
+        size: null

--- a/apps/deltasite/frigate/pvc.yaml
+++ b/apps/deltasite/frigate/pvc.yaml
@@ -2,7 +2,45 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: frigate-data-pv
+  name: frigate-config-pv
+  namespace: default
+spec:
+  storageClassName: local-data
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: ${host_path_base}/frigate-config
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - teslatron
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-config
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-data
+  volumeName: frigate-config-pv
+  resources:
+    requests:
+      storage: 1Mi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: frigate-media-pv
   namespace: default
 spec:
   storageClassName: local-data
@@ -13,7 +51,7 @@ spec:
   volumeMode: Filesystem
   persistentVolumeReclaimPolicy: Retain
   local:
-    path: ${host_path_base}/frigate
+    path: ${host_path_base}/frigate-media
   nodeAffinity:
     required:
       nodeSelectorTerms:
@@ -26,13 +64,13 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: frigate-data-pvc
+  name: frigate-media-pvc
   namespace: default
 spec:
   accessModes:
     - ReadWriteMany
   storageClassName: local-data
-  volumeName: frigate-data-pv
+  volumeName: frigate-media-pv
   resources:
     requests:
       storage: 1Mi

--- a/apps/teslops/frigate/patch.yaml
+++ b/apps/teslops/frigate/patch.yaml
@@ -6,90 +6,14 @@ metadata:
   namespace: default
 spec:
   values:
-    coral:
-      enabled: true
-    config: |
-      mqtt:
-        enabled: True
-        host: homeassistant01.glenside.lan
-      record:
-        enabled: True
-        sync_recordings: True
-        retain:
-          days: 30
-          mode: all
-      detectors:
-        coral:
-          type: edgetpu
-          device: usb
-      objects:
-        track:
-          - person
-          - cat
-          - bird
-          - dog
-          - elephant
-      birdseye:
-        enabled: True
-        mode: continuous
-      cameras:
-        carpark:
-          detect:
-            enabled: True
-          ffmpeg:
-            inputs:
-              - path: rtsp://admin:adminadmin@cam01:554//h265Preview_01_main
-                roles:
-                  - record
-                  - audio
-              - path: rtsp://admin:adminadmin@cam01:554//h264Preview_01_sub
-                roles:
-                  - detect
-        backyard:
-          detect:
-            enabled: True
-          ffmpeg:
-            inputs:
-              - path: rtsp://cam03:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - record
-                  - detect
-        sidepath:
-          detect:
-            enabled: True
-          ffmpeg:
-            inputs:
-              - path: rtsp://cam02:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - record
-                  - detect
-        driveway:
-          detect:
-            enabled: True
-          ffmpeg:
-            inputs:
-              - path: rtsp://cam04:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - record
-                  - detect
-        frontdoor:
-          detect:
-            enabled: True
-          ffmpeg:
-            inputs:
-              - path: rtsp://cam05:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - record
-                  - detect
-        shedwall:
-          detect:
-            enabled: True
-          ffmpeg:
-            inputs:
-              - path: rtsp://cam06:554/user=admin_password=tlJwpbo6_channel=1_stream=0.sdp?real_stream
-                roles:
-                  - record
-                  - detect
     persistence:
+      config:
+        existingClaim: frigate-config
+        type: null
+        accessMode: null
+        size: null
       media:
         existingClaim: frigate-data-pvc
+        type: null
+        accessMode: null
+        size: null

--- a/apps/teslops/frigate/pvc.yaml
+++ b/apps/teslops/frigate/pvc.yaml
@@ -2,6 +2,44 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
+  name: frigate-config-pv
+  namespace: default
+spec:
+  storageClassName: local-ultrapool
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: ${host_path_base}/frigate-config
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - teslatron
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-config
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-ultrapool
+  volumeName: frigate-config-pv
+  resources:
+    requests:
+      storage: 1Mi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
   name: nfs-frigate-data-pv
   namespace: default
 spec:


### PR DESCRIPTION
Stop using the frigate OG helm chart and use the standard app-template
one used in the rest of our apps.

For safety this will be rolled out manually, as it needs some work to
back up the frigate config and database and move them to their new
locations.

Both teslops and deltasite are moved to explicit PVCs for control rather
than the auto-provisioned PVs so the backup and move can be done in one
go
