### PR TITLE
Add mount of audiobooks shared path

### DIFF
--- a/apps/gammasite-prod/audiobookshelf/patch.yaml
+++ b/apps/gammasite-prod/audiobookshelf/patch.yaml
@@ -25,3 +25,5 @@ spec:
         type: null
         accessMode: null
         size: null
+      audiobooks:
+        existingClaim: audiobookshelf-audiobooks

--- a/apps/gammasite-prod/audiobookshelf/pvc.yaml
+++ b/apps/gammasite-prod/audiobookshelf/pvc.yaml
@@ -112,3 +112,41 @@ spec:
   resources:
     requests:
       storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: audiobookshelf-audiobooks-pv
+  namespace: default
+spec:
+  storageClassName: local-datapool
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: /datapool/share/Audiobooks
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - gammatron
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audiobookshelf-audiobooks
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-datapool
+  volumeName: audiobookshelf-audiobooks-pv
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
The intention is that libation will keep exporting to this but
audiobookshelf can just use the shared path directly instead of needing
to copy separately
