### PR TITLE
Disable nextcloud replicas

### DIFF
--- a/apps/base/nextcloud.yaml
+++ b/apps/base/nextcloud.yaml
@@ -26,6 +26,7 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    replicaCount: 0
     nextcloud:
       host: nextcloud.${cluster_ext_domain}
       phpConfigs:


### PR DESCRIPTION
This is having issues starting up due to domain names in healthchecks,
so disabling it for now until the cluster settles down
