### PR TITLE
Revert "Disable nextcloud replicas"

### DIFF
--- a/apps/base/nextcloud.yaml
+++ b/apps/base/nextcloud.yaml
@@ -26,7 +26,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    replicaCount: 0
     nextcloud:
       host: nextcloud.${cluster_ext_domain}
       phpConfigs:


### PR DESCRIPTION
This reverts commit 200949e28b59796e1cf3e7b8591b343295dce403, the issue was that config.php is only updated with
trusted domains on creation so the change was not being applied from the pod environment vars at all.

Manually changed it and we are running now.
