### PR TITLE
Revert "Update ghcr.io/cloudnative-pg/cloudnative-pg Docker tag to v1.27.0"

### DIFF
--- a/apps/gammasite-prod/pg-cluster/operator.yaml
+++ b/apps/gammasite-prod/pg-cluster/operator.yaml
@@ -28,4 +28,4 @@ spec:
   values:
     image:
       repository: ghcr.io/cloudnative-pg/cloudnative-pg
-      tag: 1.27.0
+      tag: 1.26.1


### PR DESCRIPTION
Reverts garvbox/gitopsokat#1141

This was streaming logs on operator startup so reverting as suspect incompatibility