### PR TITLE
Bring plex back online

### DIFF
--- a/apps/gammasite-prod/plexmediaserver/patch.yaml
+++ b/apps/gammasite-prod/plexmediaserver/patch.yaml
@@ -12,9 +12,6 @@ spec:
         kubernetes.io/hostname: gammatron
       securityContext:
         supplementalGroups: [44, 109] # Extra groups for access to hardware encode/decode
-    controllers:
-      main:
-        replicas: 0
     persistence:
       config:
         existingClaim: plexmediaserver-config


### PR DESCRIPTION
This is done to enable migration, and should be online only for a while
(hopefully)
