### PR TITLE
Add frigate deployment Gammasite

### DIFF
--- a/apps/gammasite-prod/frigate/kustomization.yaml
+++ b/apps/gammasite-prod/frigate/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pvc.yaml
+  - ../../base/frigate.yaml
+patchesStrategicMerge:
+  - patch.yaml

--- a/apps/gammasite-prod/frigate/patch.yaml
+++ b/apps/gammasite-prod/frigate/patch.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: frigate
+  namespace: default
+spec:
+  values:
+    service:
+      main:
+        type: LoadBalancer
+        externalTrafficPolicy: Local
+        annotations:
+          metallb.universe.tf/loadBalancerIPs: ${metallb_ip_frigate}
+    persistence:
+      config:
+        existingClaim: frigate-config
+        type: null
+        accessMode: null
+        size: null
+      media:
+        existingClaim: frigate-data-pvc
+        type: null
+        accessMode: null
+        size: null

--- a/apps/gammasite-prod/frigate/pvc.yaml
+++ b/apps/gammasite-prod/frigate/pvc.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: frigate-config-pv
+  namespace: default
+spec:
+  storageClassName: local-data
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: ${host_path_base}/frigate-config
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - gammatron
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-config
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-data
+  volumeName: frigate-config-pv
+  resources:
+    requests:
+      storage: 1Mi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: frigate-media-pv
+  namespace: default
+spec:
+  storageClassName: local-data
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: "/datapool/cctv/frigate"
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - gammatron
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-media-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: local-data
+  volumeName: frigate-media-pv
+  resources:
+    requests:
+      storage: 1Mi

--- a/apps/gammasite-prod/kustomization.yaml
+++ b/apps/gammasite-prod/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
   - ./unpackerr
   - ./wizarr
   - ./pg-cluster
+  - ./frigate

--- a/clusters/gammasite-prod/apps.yaml
+++ b/clusters/gammasite-prod/apps.yaml
@@ -35,4 +35,5 @@ spec:
       metallb_ip_plex: 192.168.20.23
       metallb_ip_syncthing: 192.168.20.24
       metallb_ip_influx: 192.168.20.25
+      metallb_ip_frigate: 192.168.20.26
       wl_source_range: 192.168.0.0/16,10.0.0.0/8


### PR DESCRIPTION
Copied existing frigate and updated mountpoints for gammatron storage
setup. This is to take in new reolink cams for local usage. may be moved
external to cluster in future.
