### PR TITLE
Update default startup checks for frigate

### DIFF
--- a/apps/base/frigate.yaml
+++ b/apps/base/frigate.yaml
@@ -43,10 +43,10 @@ spec:
                   httpGet:
                     path: /api/version
                     port: &port 5000
-                  initialDelaySeconds: 10
+                  initialDelaySeconds: 30
                   periodSeconds: 10
                   timeoutSeconds: 1
-                  failureThreshold: 3
+                  failureThreshold: 30
               readiness: *probes
               startup:
                 enabled: false

--- a/apps/deltasite/frigate/patch.yaml
+++ b/apps/deltasite/frigate/patch.yaml
@@ -6,23 +6,6 @@ metadata:
   namespace: default
 spec:
   values:
-    controllers:
-      main:
-        containers:
-          main:
-            probes:
-              liveness: &probes
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /api/version
-                    port: 5000
-                  initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 30
-              readiness: *probes
     service:
       main:
         type: LoadBalancer


### PR DESCRIPTION
Newer versions taking a while to start up so applying the changes from
the pi to all instances
