### PR TITLE
Add grafana and influxdb to oaklodge-gammatron

### DIFF
--- a/apps/oaklodge-gammatron/grafana/kustomization.yaml
+++ b/apps/oaklodge-gammatron/grafana/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/grafana.yaml
+  - pvc.yaml
+patchesStrategicMerge:
+  - patch.yaml

--- a/apps/oaklodge-gammatron/grafana/patch.yaml
+++ b/apps/oaklodge-gammatron/grafana/patch.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana
+  namespace: default
+spec:
+  values:
+    persistence:
+      existingClaim: grafana-config
+      type: null
+      size: null

--- a/apps/oaklodge-gammatron/grafana/pvc.yaml
+++ b/apps/oaklodge-gammatron/grafana/pvc.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: grafana-config-pv
+  namespace: default
+spec:
+  storageClassName: local-rocketpool
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: ${host_path_base}/grafana/config
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - gammatron
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-config
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-rocketpool
+  volumeName: grafana-config-pv
+  resources:
+    requests:
+      storage: 1Mi

--- a/apps/oaklodge-gammatron/influxdb/kustomization.yaml
+++ b/apps/oaklodge-gammatron/influxdb/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/influxdb.yaml
+  - pvc.yaml
+patchesStrategicMerge:
+  - patch.yaml

--- a/apps/oaklodge-gammatron/influxdb/patch.yaml
+++ b/apps/oaklodge-gammatron/influxdb/patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: influxdb
+  namespace: default
+spec:
+  values:
+    persistence:
+      influxdata:
+        existingClaim: influxdb-data
+        type: null
+        accessMode: null
+        size: null

--- a/apps/oaklodge-gammatron/influxdb/patch.yaml
+++ b/apps/oaklodge-gammatron/influxdb/patch.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: default
 spec:
   values:
+    service:
+      main:
+        type: LoadBalancer
+        externalTrafficPolicy: Local
+        annotations:
+          metallb.universe.tf/loadBalancerIPs: ${metallb_ip_influxdb}
     persistence:
       influxdata:
         existingClaim: influxdb-data

--- a/apps/oaklodge-gammatron/influxdb/pvc.yaml
+++ b/apps/oaklodge-gammatron/influxdb/pvc.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: influxdb-data-pv
+  namespace: default
+spec:
+  storageClassName: local-rocketpool
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: ${host_path_base}/influxdb/data
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - gammatron
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: influxdb-data
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-rocketpool
+  volumeName: influxdb-data-pv
+  resources:
+    requests:
+      storage: 1Mi

--- a/apps/oaklodge-gammatron/kustomization.yaml
+++ b/apps/oaklodge-gammatron/kustomization.yaml
@@ -22,3 +22,5 @@ resources:
   - ./pg-cluster
   - ./nextcloud
   - ./deesl
+  - ./grafana
+  - ./influxdb

--- a/clusters/oaklodge-gammatron/apps.yaml
+++ b/clusters/oaklodge-gammatron/apps.yaml
@@ -33,6 +33,7 @@ spec:
       metallb_ip_deluge: 192.168.20.42
       metallb_ip_jellyfin: 192.168.20.43
       metallb_ip_frigate: 192.168.20.44
+      metallb_ip_influxdb: 192.168.20.45
       metallb_ip_mqtt: 192.168.20.47
       wl_source_range: 192.168.0.0/16,10.0.0.0/8
       host_path_base: /rocketpool/kube/pvs


### PR DESCRIPTION
- Add gammatron overlays for grafana and influxdb
- Use local-rocketpool PVs at /rocketpool/kube/pvs/grafana/config and /rocketpool/kube/pvs/influxdb/data
- Wire both into apps/oaklodge-gammatron/kustomization.yaml
- Validated with flux build kustomization for oaklodge-gammatron apps